### PR TITLE
extends に'plugin:pretteir/recommended'を追加

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
   "eslintConfig": {
     "extends": [
       "react-app",
-      "react-app/jest"
+      "react-app/jest",
+      "plugin:prettier/recommended"
     ]
   },
   "browserslist": {


### PR DESCRIPTION
npm start した時に Error: "prettier/react" has been merged into "prettier" in eslint-config-prettier 8.0.0.がでるのでextends に”plugin:pretteir/recommended”を追加した